### PR TITLE
Add ticket endpoint to top-menu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:11-alpine
+RUN mkdir /src
+WORKDIR /src
+COPY . /src
+RUN npm install && npm run build
+EXPOSE 8080
+CMD ["npm", "run", "serve"] 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker-compose +1.23
 ### Running
 
 ```bash
-docker-compose up # or docker-compose -d up if you want to dettach it from the terminal
+docker-compose up # or docker-compose up -d if you want to dettach it from the terminal
 ```
 
 Then access http://localhost:8080/index.html

--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ $ npm run build
 # Serve o site na porta 8080
 $ npm run serve
 ```
+
+## Desenvolvimento:
+
+### Req
+
+Docker +18.06
+docker-compose +1.23
+
+### Running
+
+```bash
+docker-compose up # or docker-compose -d up if you want to dettach it from the terminal
+```
+
+Then access http://localhost:8080/index.html

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+  pybr_site:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: "pybr_site"
+    environment:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/src/node_modules
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./:/src

--- a/src/templates/partials/main.hbs
+++ b/src/templates/partials/main.hbs
@@ -10,11 +10,14 @@
     <div class="nav">
         <nav class="header" id="header-nav">
             <ul>
-                <li>
+               <li>
                     <a href="#section-about">evento</a>
                 </li>
                 <li>
                     <a href="#section-keynote">keynotes</a>
+                </li>
+                <li>
+                    <a href="https://pythonbrasil2019.eventbrite.com.br">ingresso</a>
                 </li>
                 <!-- <li>
                     <a href="#section-lineup">programação</a>


### PR DESCRIPTION
This adds the ticket endpoint to the top "header" (that's not a header but it's named like that...) so it's easier for someone to always have the link in plain sight. 