### PR TITLE
Isolar o node na imagem docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
 FROM node:11-alpine
+RUN apk --update --no-cache \
+      add  \
+      automake \
+      git \
+      alpine-sdk  \
+      nasm  \
+      autoconf  \
+      build-base \
+      zlib \
+      zlib-dev \
+      libpng \
+      libpng-dev\
+      libwebp \
+      libwebp-dev \
+      libjpeg-turbo \
+      libjpeg-turbo-dev
 RUN mkdir /src
 WORKDIR /src
 COPY . /src

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,3 +12,5 @@ services:
       - "8080:8080"
     volumes:
       - ./:/src
+      - /src/node_modules
+      - /src/dist


### PR DESCRIPTION
O `docker-compose.yaml` tinha um volume copiando o diretório do projeto inteiro pra dentro do `/src/`. O problema ao fazer isso é que tanto o `node_modules` quanto o `dist` seriam apagados _se eles já não existissem no diretório do projeto no host_. Adicionar `/src/dist/` e `/src/node_modules` nos volumes do `docker-compose.yaml` resolvem esse problema.

Aí a questão é que os módulos node do `gulp-imagemin` precisariam ser compilados durante o build da imagem pro docker. E pra isso era necessário instalar as dependências de compilação também (as mudanças no `Dockerfile` fazem apenas isso, seguindo [uma solução em outra issue](https://github.com/sindresorhus/gulp-imagemin/issues/236#issuecomment-292611025).

Finalmente, como conseqüência destas mudanças, a versão do node no host (no seu pc, não no docker) pode ser qualquer uma (pode até não ter node). E não é necessário fazer `npm install` ou `npm run build` no host pra poder rodar o ambiente de desenvolvimento no docker.